### PR TITLE
Add support for map_override file on build

### DIFF
--- a/buildfusilli.sh
+++ b/buildfusilli.sh
@@ -80,6 +80,11 @@ sed -Ei "s/(BUILD_TIME_DAY)\s+[[:digit:]]+/\1 `date +%-d`/" _std/__build.dm
 sed -Ei "s/(BUILD_TIME_MONTH)\s+[[:digit:]]+/\1 `date +%-m`/" _std/__build.dm
 sed -Ei "s/(BUILD_TIME_HOUR)\s+[[:digit:]]+/\1 `date +%-H`/" _std/__build.dm
 sed -Ei "s/(BUILD_TIME_MINUTE)\s+[[:digit:]]+/\1 `date +%-M`/" _std/__build.dm
+if [[ -f ${COOLSERV}/map_override ]]
+then
+    map=`cat ${COOLSERV}/map_override`
+    sed -i "1s/^/$map\n/" ${DMB_NAME}.dme
+fi
 
 echo "########## Stage 2: DreamMaker" >> ${COOLSERV}/buildlog.txt
 


### PR DESCRIPTION
Adds support for map overrides during build, in the form of a file called "map_override" placed in the coolserv directory that contains the map override define e.g. "#define MAP_OVERRIDE_CHUNK", which will be placed at the top of the dme before it's built. One important thing to note is that if there is another MAP_OVERRIDE uncommented in __build.dm it will use that instead, because __build.dm is included further down than the map override is placed, so if this is merged and put into use then the master branch will need to have all map overrides commented out. 